### PR TITLE
quick fix for new "prop" and "removeProp" functions in jQuery 1.6

### DIFF
--- a/jquery.livequery.js
+++ b/jquery.livequery.js
@@ -218,7 +218,7 @@ $.extend($.livequery, {
 });
 
 // Register core DOM manipulation methods
-$.livequery.registerPlugin('append', 'prepend', 'after', 'before', 'wrap', 'attr', 'removeAttr', 'addClass', 'removeClass', 'toggleClass', 'empty', 'remove', 'html');
+$.livequery.registerPlugin('append', 'prepend', 'after', 'before', 'wrap', 'attr', 'removeAttr', 'addClass', 'removeClass', 'toggleClass', 'empty', 'remove', 'html', 'prop', 'removeProp');
 
 // Run Live Queries when the Document is ready
 $(function() { $.livequery.play(); });


### PR DESCRIPTION
Noticed that a livequery on "input:disabled" wasn't working 100% properly with 1.6 because of the new properties API, so this fixes it.  Haven't tested compatibility with older versions of jQuery, however.  Figured I'd share back, even though you haven't touched this code in a while -- thanks for writing such a useful plugin. :)
